### PR TITLE
Add shorten-string transform

### DIFF
--- a/transforms/shorten-string/transform.json
+++ b/transforms/shorten-string/transform.json
@@ -1,0 +1,14 @@
+{
+    "name": "shorten-string",
+    "type": "static",
+    "attributes": {
+        "baseAttribute": {
+            "attributes": {
+                "name": "attributeName"
+            },
+            "type": "identityAttribute"
+        },
+        "value": "#set($length = 10)#if($baseAttribute.length() > $length)$baseAttribute.substring(0,$length)#{else}$baseAttribute#end"
+    },
+    "internal": false
+}


### PR DESCRIPTION
This transform returns up to the first X characters of the specified string. This is useful for situations where the string may contain fewer characters than the specified length, which currently causes an error with the existing `substring` primitive.

To use, modify the attribute being referenced to point to the desired target, and update the $length value specified on Line 11 to reflect the desired length.