### PR TITLE
Get Manager Distinguished Name

### DIFF
--- a/transforms/Get Manager Distinguished Name/Get Manager Distinguished Name Transform
+++ b/transforms/Get Manager Distinguished Name/Get Manager Distinguished Name Transform
@@ -1,0 +1,22 @@
+{
+    "name": "Get Manager Distinguished Name",
+    "type": "firstValid",
+    "attributes": {
+        "values": [
+            {
+                "attributes": {
+                    "value": "$identity.manager.attributes.distinguishedName"
+                },
+                "type": "static"
+            },
+            {
+                "attributes": {
+                    "value": ""
+                },
+                "type": "static"
+            }
+        ],
+        "ignoreErrors": "true"
+    },
+    "internal": false
+}

--- a/transforms/Get Manager Distinguished Name/README.MD
+++ b/transforms/Get Manager Distinguished Name/README.MD
@@ -1,0 +1,7 @@
+The Get Manager Distinguished Name Transform pulls the data stored in the identities managers attribute "Distinguished Name", which should be set up to import the identities distinguishedName from Active Directory. 
+
+This way, the distinguishedName of a users manager will be populated in an identity attribute set up with this transform. 
+
+Allowing this identity attribute to be set up with attribute sync to "manager" in Active Directory. 
+
+Result: As a users manager is updated in IdentityNow, the users manager will also be updated in Active Directory automatically. If the user does not have a manager, this attribute will show as blank. 

--- a/transforms/Timezone/README.md
+++ b/transforms/Timezone/README.md
@@ -1,0 +1,5 @@
+The Local Time Lookup Offset Transform looks at a user’s Country and Location attributes in the "External Users" Source and uses these values to perform date maths on the date and time now. The date maths do two things:
+
+First:, they add 7 hours for every country or location, this is to ensure the account disabled 7 hours early (5PM on the users end date, rather than midnight).
+
+Second: It adds or removes hours based on the users Timezone, determined by a user’s Country and Location attributes in the "External Users" Source

--- a/transforms/Timezone/Timezone.json
+++ b/transforms/Timezone/Timezone.json
@@ -1,0 +1,120 @@
+{
+    "attributes": {
+        "table": {
+            "USA": {
+                "attributes": {
+                    "table": {
+                        "New York": {
+                            "attributes": {
+                                "expression": "now+3h",
+                                "roundUp": false
+                            },
+                            "type": "dateMath"
+                        },
+                        "San Francisco": {
+                            "attributes": {
+                                "expression": "now",
+                                "roundUp": false
+                            },
+                            "type": "dateMath"
+                        },
+                        "default": {
+                            "attributes": {
+                                "expression": "now+3h",
+                                "roundUp": false
+                            },
+                            "type": "dateMath"
+                        }
+                    },
+                    "input": {
+                        "attributes": {
+                            "sourceName": "External Users",
+                            "attributeName": "Location"
+                        },
+                        "type": "accountAttribute"
+                    }
+                },
+                "type": "lookup"
+            },
+            "CAN": {
+                "attributes": {
+                    "expression": "now+3h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "CHN": {
+                "attributes": {
+                    "expression": "now+15h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "HKG": {
+                "attributes": {
+                    "expression": "now+15h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "CHE": {
+                "attributes": {
+                    "expression": "now+8h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "DEU": {
+                "attributes": {
+                    "expression": "now+8h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "NLD": {
+                "attributes": {
+                    "expression": "now+8h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "POL": {
+                "attributes": {
+                    "expression": "now+8h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "GBR": {
+                "attributes": {
+                    "expression": "now+7h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "IRL": {
+                "attributes": {
+                    "expression": "now+7h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            },
+            "default": {
+                "attributes": {
+                    "expression": "now+7h",
+                    "roundUp": false
+                },
+                "type": "dateMath"
+            }
+        },
+        "input": {
+            "attributes": {
+                "sourceName": "External Users",
+                "attributeName": "Country"
+            },
+            "type": "accountAttribute"
+        }
+    },
+    "type": "lookup",
+    "name": "Local Time Lookup Offset External Users"
+}

--- a/transforms/find-latest-date/transform.json
+++ b/transforms/find-latest-date/transform.json
@@ -1,0 +1,185 @@
+{
+    "name": "LastActiveDate",
+    "type": "firstValid",
+    "attributes": {
+        "values": [
+            {
+                "type": "dateFormat",
+                "attributes": {
+                    "input": {
+                        "type": "static",
+                        "attributes": {
+                            "adLastLogon": {
+                                "type": "dateFormat",
+                                "attributes": {
+                                    "input": {
+                                        "type": "firstValid",
+                                        "attributes": {
+                                            "values": [
+                                                {
+                                                    "type": "accountAttribute",
+                                                    "attributes": {
+                                                        "attributeName": "lastLogon",
+                                                        "sourceName": "Active Directory"
+                                                    }
+                                                },
+                                                {
+                                                    "attributes": {
+                                                        "value": "125911584000000000"
+                                                    },
+                                                    "type": "static"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "inputFormat": "EPOCH_TIME_WIN32",
+                                    "outputFormat": "yyMMddHH"
+                                }
+                            },
+                            "adLastLogonTimestamp": {
+                                "type": "dateFormat",
+                                "attributes": {
+                                    "input": {
+                                        "type": "firstValid",
+                                        "attributes": {
+                                            "values": [
+                                                {
+                                                    "type": "accountAttribute",
+                                                    "attributes": {
+                                                        "attributeName": "lastLogonTimestamp",
+                                                        "sourceName": "Active Directory"
+                                                    }
+                                                },
+                                                {
+                                                    "attributes": {
+                                                        "value": "125911584000000000"
+                                                    },
+                                                    "type": "static"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "inputFormat": "EPOCH_TIME_WIN32",
+                                    "outputFormat": "yyMMddHH"
+                                }
+                            },
+                            "adPwdLastSet": {
+                                "type": "dateFormat",
+                                "attributes": {
+                                    "input": {
+                                        "type": "firstValid",
+                                        "attributes": {
+                                            "values": [
+                                                {
+                                                    "type": "accountAttribute",
+                                                    "attributes": {
+                                                        "attributeName": "pwdLastSet",
+                                                        "sourceName": "Active Directory"
+                                                    }
+                                                },
+                                                {
+                                                    "attributes": {
+                                                        "value": "125911584000000000"
+                                                    },
+                                                    "type": "static"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "inputFormat": "EPOCH_TIME_WIN32",
+                                    "outputFormat": "yyMMddHH"
+                                }
+                            },
+                            "adWhenCreated": {
+                                "type": "dateFormat",
+                                "attributes": {
+                                    "input": {
+                                        "type": "firstValid",
+                                        "attributes": {
+                                            "values": [
+                                                {
+                                                    "type": "accountAttribute",
+                                                    "attributes": {
+                                                        "attributeName": "whenCreated",
+                                                        "sourceName": "Active Directory"
+                                                    }
+                                                },
+                                                {
+                                                    "attributes": {
+                                                        "value": "20000101010000.0Z"
+                                                    },
+                                                    "type": "static"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "inputFormat": "yyyyMMddHHmmss.S'Z'",
+                                    "outputFormat": "yyMMddHH"
+                                }
+                            },
+                            "azureLastInteractive": {
+                                "type": "dateFormat",
+                                "attributes": {
+                                    "input": {
+                                        "type": "firstValid",
+                                        "attributes": {
+                                            "values": [
+                                                {
+                                                    "type": "accountAttribute",
+                                                    "attributes": {
+                                                        "attributeName": "lastSignInDateTime",
+                                                        "sourceName": "Azure Active Directory"
+                                                    }
+                                                },
+                                                {
+                                                    "attributes": {
+                                                        "value": "2000-01-01T00:00:00Z"
+                                                    },
+                                                    "type": "static"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "inputFormat": "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                                    "outputFormat": "yyMMddHH"
+                                }
+                            },
+                            "azureLastNonInteractive": {
+                                "type": "dateFormat",
+                                "attributes": {
+                                    "input": {
+                                        "type": "firstValid",
+                                        "attributes": {
+                                            "values": [
+                                                {
+                                                    "type": "accountAttribute",
+                                                    "attributes": {
+                                                        "attributeName": "lastNonInteractiveSignInDateTime",
+                                                        "sourceName": "Azure Active Directory"
+                                                    }
+                                                },
+                                                {
+                                                    "attributes": {
+                                                        "value": "2000-01-01T00:00:00Z"
+                                                    },
+                                                    "type": "static"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "inputFormat": "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                                    "outputFormat": "yyMMddHH"
+                                }
+                            },
+                            "value": "#set($max=-10)#set($array = [$max.parseInt($adLastLogon),$max.parseInt($adLastLogonTimestamp),$max.parseInt($adPwdLastSet),$max.parseInt($adWhenCreated),$max.parseInt($azureLastInteractive),$max.parseInt($azureLastNonInteractive)])#foreach($val in $array)#if($val > $max)#set($max = $val)#end#end#if($max > 0)$max#end"
+                        }
+                    },
+                    "inputFormat": "yyMMddHH",
+                    "outputFormat": "ISO8601"
+                }
+            },
+            null
+        ]
+    },
+    "internal": false
+}

--- a/transforms/shorten-string/transform.json
+++ b/transforms/shorten-string/transform.json
@@ -1,0 +1,14 @@
+{
+    "name": "shorten-string",
+    "type": "static",
+    "attributes": {
+        "baseAttribute": {
+            "attributes": {
+                "name": "attributeName"
+            },
+            "type": "identityAttribute"
+        },
+        "value": "#set($length = 10)#if($baseAttribute.length() > $length)$baseAttribute.substring(0,$length)#{else}$baseAttribute#end"
+    },
+    "internal": false
+}


### PR DESCRIPTION
The Get Manager Distinguished Name Transform pulls the data stored in the identities managers attribute "Distinguished Name", which should be set up to import the identities distinguishedName from Active Directory.

This way, the distinguishedName of a users manager will be populated in an identity attribute set up with this transform.

Allowing this identity attribute to be set up with attribute sync to "manager" in Active Directory.

Result: As a users manager is updated in IdentityNow, the users manager will also be updated in Active Directory automatically. If the user does not have a manager, this attribute will show as blank.